### PR TITLE
feat: Switch to stable Rust and update rust-seq2kminmers dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ dashmap = "5.4.0"
 thread-id = "3.3.0"
 #rust-wfa2 = { git = "https://github.com/rchikhi/rust-wfa2/" }
 #libwfa = "0.1"
-rust-seq2kminmers = { git = "https://github.com/rchikhi/rust-seq2kminmers" }
+rust-seq2kminmers = { git = "https://github.com/MrTomRod/rust-seq2kminmers" }
 #rust-seq2kminmers = { path = "/pasteur/appa/homes/rchikhi/tools/rust-seq2kminmers" }
 rust-parallelfastx = { git = "https://github.com/rchikhi/rust-parallelfastx"  }
 fxhash = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapquik"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["ekimb, rayan"]
 edition = "2021"
 default-run = "mapquik"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,8 @@ Pre-requisites: [A working Rust environment](https://rustup.rs/).
 Clone the repository, and run 
 
 ```
-rustup install nightly
-cargo +nightly build --release
+cargo build --release
 ```
-
-The nightly version of `cargo` is required because `mapquik` uses experimental language features (such as SIMD and intrinsics).
 
 ## Quick start
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// mapquik v0.1.0
+// mapquik v0.1.1
 // Copyright 2020-2021 Baris Ekim, Rayan Chikhi.
 // Licensed under the MIT license (http://opensource.org/licenses/MIT).
 // This file may not be copied, modified, or distributed except according to those terms.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
 #![allow(unused_variables)]
 #![allow(non_upper_case_globals)]
 //#![allow(warnings)]
-#![feature(iter_advance_by)]
+
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;


### PR DESCRIPTION
This PR updates `mapquik` to use **stable Rust** and switches the `rust-seq2kminmers` dependency to the [MrTomRod/rust-seq2kminmers](https://github.com/MrTomRod/rust-seq2kminmers) fork (see https://github.com/rchikhi/rust-seq2kminmers/pull/5), which supports stable Rust.

Users can now build and run `mapquik` with just `cargo build --release`.

### Key Changes:
- **Removed nightly Rust requirement**: `mapquik` now builds and runs on the stable toolchain.
- **Updated `rust-seq2kminmers` dependency** to use the [my fork](https://github.com/MrTomRod/rust-seq2kminmers), which replaces unstable intrinsics with stable equivalents.
- **Bumped version to `0.1.1`** to reflect these changes.
- **Updated README**: Removed instructions for nightly Rust, as it is no longer required.

### Why?
Without these changes, I was unable to build mapquik.

I did not do enough testing. Please perform some sanity checks before merging.